### PR TITLE
Форма оплаты заказа не рабочая

### DIFF
--- a/administrator/components/com_virtuemart/classes/payment/ps_yandex_money.php
+++ b/administrator/components/com_virtuemart/classes/payment/ps_yandex_money.php
@@ -638,8 +638,9 @@ echo $ym->get_ym_params_block($host, number_format($out_sum, 2, ".", ""), $custo
 
         if (YM_SEND_CHECK) {
             $dbo = $db;
+			$user = JFactory::getUser();
             $receipt = array(
-                'customerContact' => '99',
+                'customerContact' => $user->email,
                 'items' => array(),
             );
 
@@ -719,10 +720,10 @@ echo $ym->get_ym_params_block($host, number_format($out_sum, 2, ".", ""), $custo
 		// HTML-страница с формой
 		$htmlBlock = '
             <input type="hidden"name="cms_name" value="joomla-virtuemart">
-            <input type="hidden"name="scid" value="$ym_SCID">
-            <input type="hidden" name="ShopID" value="$ym_shopID">
-            <input type="hidden" name="Sum" value="$out_sum">
-            <input type="hidden" name="CustomerNumber" value="$customerNumber">';
+            <input type="hidden"name="scid" value="'.$ym_SCID.'">
+            <input type="hidden" name="ShopID" value="'.$ym_shopID.'">
+            <input type="hidden" name="Sum" value="'.$out_sum.'">
+            <input type="hidden" name="CustomerNumber" value="'.$customerNumber.'">';
 
 		if ( $orderNumber != "" )
 		{


### PR DESCRIPTION
Вместо почты покупателя в кассу отправлялось число 99. В результате была ошибка платежа
Ошибка в скрипте: из-за неверно поставленных кавычек, в платежной форме на сайте не заполнялись настройки магазина

 - fixed customerContact in request. Before fix '99' was sent in request
 - fixed scid, ShopID, Sum, CustomerNumber wrong params in payment form